### PR TITLE
Update binary build dependencies

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.humble.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.humble.repos
@@ -4,3 +4,7 @@
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
 repositories:
+  Universal_Robots_ROS2_Description:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+    version: ros2

--- a/Universal_Robots_ROS2_Driver-not-released.rolling.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.rolling.repos
@@ -3,4 +3,8 @@
 # requires a newer version than the one currently released to the target distributions.
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
-repositories: []
+repositories:
+  Universal_Robots_ROS2_Description:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+    version: ros2


### PR DESCRIPTION
Since with recent changes we need the latest description, we should modify the dependencies files, as well.

@firesurfer could you please merge this into your branch and then squash the commits of this repo into one, so we can merge https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/633

Sorry for being that complicated, I seem to have broken Github with this PR.